### PR TITLE
Add pytest test for compose services

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Simple docker-compose for Laravel, with postgresql, reddis, nginx and php-fpm
 + `docker-compose up -d` to start all containers
 + `docker-compose down` to stop all containers
 + If you need to restart after modifying *docker-compose.yml* restart with `docker-compose down` and `docker-compose up -d`
++ Run `pytest` to execute the tests
 
 # Images
 + redis:alpine

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -1,0 +1,11 @@
+import os
+import yaml
+
+
+def test_services_exist():
+    compose_file = os.path.join(os.path.dirname(__file__), os.pardir, "docker-compose.yml")
+    with open(compose_file, 'r') as f:
+        compose = yaml.safe_load(f)
+    services = compose.get('services', {})
+    for svc in ['redis', 'postgres', 'webserver', 'php-fpm']:
+        assert svc in services


### PR DESCRIPTION
## Summary
- add a test to ensure all expected compose services are present
- document running pytest

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6866ec4b3680832b878abe31d470cfca