### PR TITLE
Fix redis typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # docker-laravel-postgres-nginx
-Simple docker-compose for Laravel, with postgresql, reddis, nginx and php-fpm
+Simple docker-compose for Laravel, with postgresql, redis, nginx and php-fpm
 # Pre-requisites
 * Docker running on the host machine.
 * Docker compose running on the host machine.


### PR DESCRIPTION
## Summary
- fix small typo in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6866ec48009c832b89e9d9f32918cab6