### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # docker-laravel-postgres-nginx
-Simple docker-compose for Laravel, with postgresql, reddis, nginx and php-fpm
+Simple docker-compose for Laravel, with postgresql, redis, nginx and php-fpm
 # Pre-requisites
 * Docker running on the host machine.
 * Docker compose running on the host machine.
@@ -9,7 +9,7 @@ Simple docker-compose for Laravel, with postgresql, reddis, nginx and php-fpm
 # Installation
 + To get started, the following steps needs to be taken:
 + Clone the repo.
-+ `cd laravel-docker-postgres` to the project directory.
++ `cd docker-laravel-postgres-nginx` to the project directory.
 + `cd` to web and run the command to create a new Laravel project into **application** directory.
 + `cd ..` to back the project directory.
 + `cp .env.example .env` to use env config file
@@ -27,15 +27,15 @@ Simple docker-compose for Laravel, with postgresql, reddis, nginx and php-fpm
 + redis:alpine
 + postgres:9.5-alpine
 + nginx:alpine
-+ php71-fpm:latest
++ php73-fpm:latest
 
 # SourceFiles
 
-## Into **sourcefiles** directory, exists others directories: **php-fpm** and **nginx**:
+## Inside the **sourcefiles** directory there are other directories: **php-fpm** and **nginx**:
 
 
 ### php-fpm: Extensions PHP and PHP.INI
-+ Dockerfile: php7.1-pgsql php7.1-gd php-redis
++ Dockerfile: php7.3-pgsql php7.3-gd php-redis
 + php-ini-overrides.ini
 
 ### nginx: nginx.conf
@@ -47,8 +47,8 @@ Simple docker-compose for Laravel, with postgresql, reddis, nginx and php-fpm
 - data(postgres)
 
 ### multiple servers:
-- create file conf of nginx in nginx directory you should use default.conf as exemple 
-- restart containers: `docker-compose down` and `docker-composer up -d`
+- create file conf of nginx in nginx directory you should use default.conf as example
+- restart containers: `docker-compose down` and `docker-compose up -d`
 
 
 # Troubleshooting


### PR DESCRIPTION
## Summary
- fix typos in README for clarity and correct project names

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866eb8ee9e0832b9783ec2793b476b9